### PR TITLE
Fix scraper: problems with some fields.

### DIFF
--- a/src/etls/bocm/utils.py
+++ b/src/etls/bocm/utils.py
@@ -66,7 +66,7 @@ def metadata_from_doc(soup, seccion: str, cve: str) -> tp.List[str]:
                 organo = paras[0]
 
         if seccion == "4":
-            subseccion_name = paras[0]
+            subseccion_name = "ADMINISTRACIÓN DE JUSTICIA"
         if seccion == "5":
             subseccion_name = "OTROS ANUNCIOS"
             anunciante = paras[0]


### PR DESCRIPTION
Hemos detectado que hay una serie de inconsistencias en el marcado html de ciertas propiedades en las etiquetas meta de artículos de 2022. 
![Screenshot_20240205_140208](https://github.com/bukosabino/justicio/assets/1333901/8675e364-ddf0-4cda-adc3-40d62934d4df)
![Screenshot_20240205_140153](https://github.com/bukosabino/justicio/assets/1333901/611379da-fff0-4959-90c3-d6eb734cdbaf)
![Screenshot_20240205_140102](https://github.com/bukosabino/justicio/assets/1333901/9f71c8cf-2312-4c2b-a4a5-ce1bfbffc571)



**Testeado** con un batch desde 2020 a 2023. Ejecución sin errores.

```
[2024-02-05 23:04:10,538] [11993] [INFO] [_split_documents] Splitting in chunks 64966 documents
[2024-02-05 23:05:50,384] [11993] [INFO] [_split_documents] Removing file /tmp/tmpkiq2qnee
[2024-02-05 23:05:50,384] [11993] [INFO] [_split_documents] Splitted 64966 documents in 275232 chunks
[2024-02-05 23:05:50,385] [11993] [INFO] [_load_database] Loading 275232 embeddings to database
```



