### PR TITLE
Estandarización en los boletines BOJA y BOPV

### DIFF
--- a/src/etls/boja/load.py
+++ b/src/etls/boja/load.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime
-import json
 
 import typer
 

--- a/src/etls/boja/metadata.py
+++ b/src/etls/boja/metadata.py
@@ -1,9 +1,5 @@
-import typing as tp
 from datetime import datetime
 from typing import Optional
-
-from pydantic import BaseModel, validator, Field
-import re
 
 from src.etls.common.metadata import MetadataDocument
 
@@ -21,7 +17,7 @@ class BOJAMetadataDocument(MetadataDocument):
     source_type: str = "Boletin"
 
     # Metadatos
-
+    identificador: str
     departamento: str
     tipologia: str   
 

--- a/src/etls/bopv/README.md
+++ b/src/etls/bopv/README.md
@@ -1,7 +1,7 @@
 
 # Web principal
 
-[Web principal del BOJA](https://www.euskadi.eus/web01-bopv/es/bopv2/datos/Ultimo.shtml)
+[Web principal del BOPV](https://www.euskadi.eus/web01-bopv/es/bopv2/datos/Ultimo.shtml)
 
 
 # Portal de búsqueda avanzada

--- a/src/etls/bopv/metadata.py
+++ b/src/etls/bopv/metadata.py
@@ -1,13 +1,7 @@
-import typing as tp
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, validator, Field
-import re
-
 from src.etls.common.metadata import MetadataDocument
-
-
 
 
 class BOPVMetadataDocument(MetadataDocument):
@@ -21,9 +15,9 @@ class BOPVMetadataDocument(MetadataDocument):
     source_type: str = "Boletin"
 
     # Metadatos
-
+    identificador: str
     departamento: Optional[str] = None 
-    tipologia: str   
+    tipologia: str
 
     # Links
     titulo: Optional[str] = None

--- a/src/etls/common/utils.py
+++ b/src/etls/common/utils.py
@@ -28,35 +28,38 @@ class TextLoader(BaseLoader):
             text = f.read()
         return [Document(page_content=text, metadata=self.metadata)]
 
-class ScrapeError(Exception):
+
+class ScrapperError(Exception):
     """
-    Excepción personalizada para errores de scrapeo.
+    Custom exception for scraping errors.
     """
 
     def __init__(self, message="Error durante el proceso de scraping", *args, **kwargs):
         """
-        Inicializa la excepción con un mensaje de error personalizado.
+        Initializes the exception with a custom error message.
 
-        :param message: Mensaje de error que describe el fallo.
-        :param args: Argumentos posicionales adicionales.
-        :param kwargs: Argumentos de palabra clave adicionales.
+        :param message: Error message describing the failure.
+        :param args: Additional positional arguments.
+        :param kwargs: Additional keyword arguments.
         """
         super().__init__(message, *args, **kwargs)
         self.message = message
 
     def __str__(self):
         """
-        Devuelve una representación en string de la excepción, que incluye el mensaje de error.
+        Returns a string representation of the exception, including the error message.
         """
-        return f"ScrapeError: {self.message}"
-    
+        return f"ScrapperError: {self.message}"
+
+
 class HTTPRequestException(Exception):
     """
-    Excepción para errores ocurridos durante las solicitudes HTTP realizadas por HTTPRequester.
+    Exception for errors occurring during HTTP requests made by HTTPRequester.
     """
-    def __init__(self, message="Error en la solicitud HTTP", *args):
+    def __init__(self, message="HTTP request error", *args):
         super().__init__(message, *args)
-        
+
+
 class HTTPRequester:
     user_agents = [
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
@@ -77,32 +80,31 @@ class HTTPRequester:
     @classmethod
     def get_random_user_agent(cls):
         """
-        Selecciona y devuelve un User-Agent aleatorio de la lista de user_agents.
+        Selects and returns a random User-Agent from the list of user_agents.
         """
         return random.choice(cls.user_agents)
 
     @classmethod
     def get_headers(cls):
         """
-        Genera y devuelve headers incluyendo un User-Agent aleatorio.
+        Generates and returns headers including a random User-Agent.
         """
         headers = cls.default_headers.copy()
         headers["User-Agent"] = cls.get_random_user_agent()
         return headers
 
     @staticmethod
-    def get_soup(url, timeout=10):  
+    def get_soup(url, timeout=10, markup='html.parser'):
         """
-        Realiza una solicitud HTTP GET al URL proporcionado, utilizando headers aleatorios,
-        y devuelve un objeto BeautifulSoup si la respuesta es exitosa. Si hay un error
-        o se supera el tiempo de espera, lanza HTTPRequestException.
+        Performs an HTTP GET request to the provided URL, using random headers, and returns a BeautifulSoup
+        object if the response is successful. If there is an error or timeout, it throws HTTPRequestException.
         """
         headers = HTTPRequester.get_headers()
         try:
             response = requests.get(url, headers=headers, timeout=timeout)
             response.raise_for_status()
-            return BeautifulSoup(response.content, 'html.parser')
+            return BeautifulSoup(response.content, markup)
         except Timeout as e:
-            raise HTTPRequestException(f"La solicitud HTTP excedió el tiempo de espera: {e}")
+            raise HTTPRequestException(f"HTTP request timed out: {e}")
         except requests.RequestException as e:
-            raise HTTPRequestException(f"Error al realizar la solicitud HTTP: {e}")
+            raise HTTPRequestException(f"HTTP request failed: {e}")


### PR DESCRIPTION
Algunos cambios:

* Añadido de `identificador` como metadato para ambos boletines.
* ScrapeError -> ScrapperError
* Uso de inglés en los paquetes comunes (src/etls/common/utils.py)
* Sustitución de prints por excepciones. En el servidor, no recogemos los prints, solo excepciones y logger.
* Borrado de imports innecesarios