### PR TITLE
Implementación del BOA (Comunidad Autónoma de Aragón)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,6 +31,7 @@ collections:
   - bopz
   - bopv
   - boja
+  - boa
 
 # Openai
 llm_model_name: 'gpt-3.5-turbo-0125'  # 'gpt-3.5-turbo-1106', 'gpt-4-1106-preview'

--- a/src/etls/boa/README.md
+++ b/src/etls/boa/README.md
@@ -1,0 +1,41 @@
+
+# Web principal
+
+[Web principal del BOA](https://www.boa.aragon.es/#/)
+
+# Portal de búsqueda avanzada
+
+[Portal de búsqueda avanzada](https://www.boa.aragon.es/#/busquedaboletin)
+
+# Ejemplo de documento scrapeado
+
+[Doc1](https://www.boa.aragon.es/#/resultado-detalle?item=N4Igcg8gTgJgpgOxALhARgATwwZgJwgA0IAIhAMJgogAMNA7HvgGw41EgBicAxgBYBDAAoBXAEYAbAJY8BPKQHskqAEw0VAFho40ODmBEBbOFAViFEuABcpykAFYVHAMq95S6gElPAOgwBBESsFKCkYAXgAZwwATwwhE0ilAQkXcUi3RTsBAEoMMAVDMSgBQylEYMjCDEipKxE5LLhouAxbeXgEeQFIjm5%2BCKlIgAcFWvc7NU11FWYOACUBBABzBWp5gFFnCAAZAFVyTwBlqmINsqSoahINoX95gBV-AFkNsAeIDBuMZ38wTxI-hIHAedREEjWqE2232hxOWFaswRGAAZnBiiYFMiphpqtgJAIMABxEyIbrI1w8YJQDAALQEJVWAC9Cd5qqMaQSMABHEStDIYKDNPkSABurTgEgww1MPDgMCkZQqWOwMoUoqGUgAzwh2SEMJKakMrHBDIT8VIMQjassEI0dXjWiIENK%2BZFgsiAFJwFECeolZEbXlSUbI8gMhUWBTLAC3hMQBqlAAkxsM6ikMHsEFJxVBalYGYoMAAyXkKKwAbmeUmWIp%2BJnFVlLInLFZ8ILgAA9gtQADzDDA8AmRSIAXgAOiBhgJlnAALS2BAmOcm7sYScAPme8qkSxNGHmzQsInkOuxmGwACtnUXsFMcI6MFySUKuruKbxqXSGTOFCyMN4GAABTNq2ABCFjWDGLoQCiMi7lK2D%2BIyOqgZW1QIAAX8YpgYLoNCPmgNDIte0gqoi6g4Dk1QCrY8FatKso7kqCAeqqpgarUDrSvqhq1O6prmq00hWlENZ2qeurIs6rrNGxrTer6-pCRgQYiCG5EYOGsCKBCsbxi6hopiM6ZSlmOaJOmoRYmhVY1nWrhQI2tk%2BL2AD0wwbv2g7DmOk7TrOC4IEuUArl2VjriAG6cLYKRSCyMBYoawwEkymkys0FT2i62BJNI8j1FE1ScQWT6EmqwxuqVQpxQl5X6ly5CFJqZ7YK4lg8JJ1riREhIZj6n4KNUcTYDwSgoiEZThDAg5KE%2BKpDJVclJYZUqyMMMb1BCAGAfAUpWJt4JYt4ngIlKJC8EKHo4PQblqGgaCPgAHMiZpQGljpSkSZjlFACCachM7cblkqZK1rTDIkyRSnJfpBIWWJxGqnHajlEOpT0BouhC0RyqxpjRHt9ZOfBWKA6sCAAJeE60zgpCIMDVLDxKkm%2BKmUl%2B9KMn%2BrKeEzhmXiY8juMiw6zYYkMmmz0SWMsKTGKxrR%2BqEYjqeEVSCsKkrisg7med5Q49H5U4zvOi7LquEWbgURQlDShIkD4ABVPxKO%2B2DcEyGA7FqkNe9OAaGlEpqQwAj%2BRUpLe6mmKXDAbYGpGlhhGunRnGWOJhgxlpgWZnZrm%2BYIyWZaVtWtaGo5zkl22eteQOhsjhOJuBeboWW5FG5NfjhJchlGSKweR4SCeqPVLyrT-TxS6orYGA94SorpxEZTZu6JQ2KKAjVLIYitLYJpQKMIWazwIh5ppKR1XPA9ciQUhCp1qMs6%2B5JE5XpMBNzVM0z89OMxnyVUqaRksYDWY1WIRCxOVBkNgaRExgOnG06kKhK0QvyEQrpJAyGygAqUtkIKWAOjBOC3Q0GfyBggWyj5wETSgFNCIs1sYLRGFVFamcYExlPttDQT0fAqDOhgB44UsSHhRM6BUiVRaEh2HAEaFcGwf3JkoamFI-7VAEGqMQkCeI0gujwK6WIZHLCGASDeWIVB3ToLiZEbBkQKnkKaDEn1iQ-RMJPJCKEpJxATDjOeUADpcLGHhFQmA4hoBUPw-E0jZG4DwJYtA9hCLIgUFScQQpnFCCYgqFiHp-AwBXsadeOYsRNUMJhNGZVoh5IKWvRoShmjxEwlg2QkRXIeTrj5I2TcApm2ChbcKHcua-hZNUJE2A0QYlwnedQGgfBzm9oSF8KCPxUn1NgIZzJebVCEMreChIdmpTPHTM%2BAg2meQ4E1BUqxnh%2BhMLuagHA9hQAkEIGAKJqAAAM%2BBWCsMMSIyA3JuQAO4gp8OYU5P4KY%2BGaG5Hgxi5xiFsG5DYYEID%2BDcmBeYzhyBEk8AAfnIM8Ego4ABqGx5gQDAp6YszwdgAGlKWjl0GoJ6T0aDMDUFoDQAAWr5Py-kAuBaC8FPhIVKGhZEWF8LEUIGRai9FmLsW4oJUS0l5LKXUtpQysCTKcAsqemgVgNAuXcowGa81FqLWPOeWBcgEBnifO%2Bb8-5gKQVArBQoCFX8JVSqkAipFKK0UYqxTi-FhLiVkopVSml9LGXMpoE9egT1mB0DYDgXlTqBWuuFZ60V3qYVwr9TKuVQbFWhpVRG9V0atVxr1QmxgzAiJptNZa1tVriCRD4AoIFlIJgoCsFAPkHau09vSJkDwyAB1DpAJ27t5whghH7YOuAABfIAA&from=busquedaCalendarioHome&rutaActual=%2Fresultados-fecha)
+
+# Funcionamiento del scraper
+
+A través del enlace https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI, y con los parámetros adecuados (véase la clase BOAScrapper en scrapper.py), el portal del BOA devuelve directamente un archivo en formato JSON que contiene los metadatos y el contenido del boletín.
+
+Ejemplo (alineado con el documento anterior):
+```text
+{
+"NOrden" : "1 de 39",
+"DOCN" : "007939630",
+"FechaPublicacion" : "20240313",
+"Numeroboletin" : "52",
+"Seccion" : "II. Autoridades y Personal",
+"Subseccion" : "a) Nombramientos, situaciones e incidencias",
+"Fechadisposicion" : "20240226",
+"Rango" : "RESOLUCIÓN",
+"Emisor" : "DEPARTAMENTO DE SANIDAD",
+"Titulo" : "RESOLUCIÓN de 26 de febrero de 2024, de la Gerencia de Sector Zaragoza II, por la que se resuelve el procedimiento de provisión, por el sistema de libre designación, de un puesto de Jefatura de Equipo de Cardiología en el Hospital Universitario &quot;Miguel Servet &quot;.",
+"Texto" : "<br/>
+Mediante Resolución de 21 de junio de 2023, de la Gerencia de Sector Zaragoza II (&quot;Boletín Oficial de Aragón &quot;, número 130, de 10 de julio de 2023), se inició procedimiento de provisión, por el sistema de libre designación, de un puesto de Jefatura de Equipo de Cardiología en el Hospital Universitario &quot;Miguel Servet &quot;. <br/>
+Finalizado el plazo de presentación de solicitudes, vista la propuesta realizada por la Comisión de Selección designada al efecto, y de conformidad con lo dispuesto en el capítulo III del título III del Decreto 37/2011, de 8 de marzo, del Gobierno de Aragón, de selección de personal estatutario y provisión de plazas en los centros del Servicio Aragonés de Salud, esta Gerencia de Sector Zaragoza II, en ejercicio de las competencias legalmente atribuidas, resuelve: <br/>
+Nombrar a D.ª Sonia de Fez López para el desempeño del puesto de Jefatura de Equipo de Cardiología en el Hospital Universitario &quot;Miguel Servet &quot;. <br/>
+Contra la presente Resolución, que no pone fin a la vía administrativa, cabe interponer recurso de alzada ante la Dirección Gerencia del Servicio Aragonés de Salud, en el plazo de un mes, contado a partir del día siguiente al de su publicación en el &quot;Boletín Oficial de Aragón &quot;, de conformidad con lo dispuesto en el artículo 48.2 del Texto Refundido de la Ley del Servicio Aragonés de Salud, aprobado por Decreto Legislativo 2/2004, de 30 de diciembre, del Gobierno de Aragón, y en los artículos 121 y 122 de la Ley 39/2015, de 1 de octubre, del Procedimiento Administrativo Común de las Administraciones Públicas. <br/>
+Zaragoza, 26 de febrero de 2024.- La Gerente de Sector de Zaragoza II, Patricia Palazón Saura.",
+"CodigoMateria" : "",
+"UrlPdf" : "`https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI?CMD=VEROBJ&MLKOB=1320880620404´`https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI?CMD=VEROBJ&MLKOB=1320881630404´              ",
+"UrlBCOM" : "`https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI?CMD=VEROBJ&MLKOB=1320878600303´`https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI?CMD=VEROBJ&MLKOB=1320879610303´                "
+}
+```

--- a/src/etls/boa/defs.py
+++ b/src/etls/boa/defs.py
@@ -1,0 +1,1 @@
+COLLECTION_NAME = "boa"

--- a/src/etls/boa/load.py
+++ b/src/etls/boa/load.py
@@ -1,0 +1,58 @@
+from datetime import date, datetime
+import json
+
+import typer
+
+from src.email.send_email import send_email
+from src.etls.boa.scrapper import BOAScrapper
+from src.etls.boa.defs import COLLECTION_NAME
+from src.etls.common.etl import ETL
+from src.initialize import initialize_app
+
+app = typer.Typer()
+
+@app.command()
+def today(init_objects=None):
+    if init_objects is None:
+        init_objects = initialize_app()
+    etl_job = ETL(config_loader=init_objects.config_loader, vector_store=init_objects.vector_store[COLLECTION_NAME])
+    boa_scrapper = BOAScrapper()
+    day = date.today()
+    docs = boa_scrapper.download_day(day)
+    if docs:
+        etl_job.run(docs)
+    subject = "[BOA] Daily ETL executed"
+    content = f"""
+    Daily ETL executed
+    - Date: {day}
+    - Documents loaded: {len(docs)} 
+    - Database used: {init_objects.config_loader['vector_store']}
+    """
+    send_email(init_objects.config_loader, subject, content)
+    
+@app.command()
+def dates(date_start: str, date_end: str, init_objects=None):
+    if init_objects is None:
+        init_objects = initialize_app()
+    etl_job = ETL(config_loader=init_objects.config_loader, vector_store=init_objects.vector_store[COLLECTION_NAME])
+    boa_scrapper = BOAScrapper()
+    docs = boa_scrapper.download_days(
+        date_start=datetime.strptime(date_start, "%Y/%m/%d").date(),
+        date_end=datetime.strptime(date_end, "%Y/%m/%d").date()
+        )        
+    if docs:
+        etl_job.run(docs)
+
+    subject = "[BOA] Load ETL executed"
+    content = f"""
+    Load ETL executed
+    - Date start: {date_start}
+    - Date end: {date_end}
+    - Documents loaded: {len(docs)} 
+    - Database used: {init_objects.config_loader['vector_store']}
+    """
+    send_email(init_objects.config_loader, subject, content)
+
+
+if __name__ == "__main__":
+    app()    

--- a/src/etls/boa/metadata.py
+++ b/src/etls/boa/metadata.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from typing import Optional
+
+from src.etls.common.metadata import MetadataDocument
+
+
+class BOAMetadataDocument(MetadataDocument):
+    """Class for keeping metadata of a BOA Document scrapped."""
+
+    # Text
+    filepath: str
+
+    # Source
+    source_name: str = "BOA"
+    source_type: str = "Boletin"
+
+    # Metadatos
+    numero_boletin: str 
+    identificador: str # DOCN
+    departamento: Optional[str] = None 
+    seccion: Optional[str] = None 
+    subseccion: Optional[str] = None 
+    rango: Optional[str] = None 
+    codigo_materia: Optional[str] = None 
+
+    # Links
+    titulo: Optional[str] = None 
+    url_pdf: str  
+    url_boletin: Optional[str] = None
+
+    fecha_disposicion: str = "" 
+    fecha_publicacion: str = ""
+    anio: Optional[str] = None
+    mes: Optional[str] = None
+    dia: Optional[str] = None
+
+    datetime_insert: str = datetime.utcnow().isoformat()
+

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -4,6 +4,7 @@ import typing as tp
 from datetime import date
 import random
 import json 
+from lxml import etree
 
 import requests
 
@@ -36,7 +37,12 @@ class BOAScrapper(BaseScrapper):
             "User-Agent": random.choice(self.user_agents),
         }    
 
-
+    def _remove_html_tags(self, text):
+        parser = etree.HTMLParser()
+        tree = etree.fromstring(text, parser)
+        clean_text = etree.tostring(tree, encoding="unicode", method='text') 
+        return clean_text.strip()
+    
     def download_day(self, day: date) -> tp.List[BOAMetadataDocument]:
         """Download all the documents for a specific date."""
         try:
@@ -73,7 +79,7 @@ class BOAScrapper(BaseScrapper):
                 if not content or not numero_boletin or not identificador or not departamento or not url_pdf or not seccion:
                     raise ScrapperError("No se pudo encontrar alguno de los elementos requeridos.")
                 
-                clean_text = content.replace('<br/>', '')
+                clean_text = self._remove_html_tags(content)
 
                 with tempfile.NamedTemporaryFile("w", delete=False, encoding='utf-8') as fn:
                     fn.write(clean_text)           

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -79,8 +79,7 @@ def _extract_metadata(doc: dict) -> tp.Dict:
         pass
 
     try:
-        fecha_disp_raw = doc["Fechadisposicion"]
-        fecha_disposicion = fecha_disp_raw[0:4]+"-"+fecha_disp_raw[4:6]+"-"+fecha_disp_raw[6:8]
+        fecha_disposicion = datetime.strptime(doc["Fechadisposicion"], "%Y%m%d").strftime("%Y-%m-%d")
         metadata_dict["fecha_disposicion"] = fecha_disposicion
     except KeyError:
         pass

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -1,7 +1,7 @@
 import logging as lg
 import tempfile
 import typing as tp
-from datetime import date
+from datetime import date, datetime
 import random
 import json 
 from lxml import etree

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -118,7 +118,7 @@ class BOAScrapper(BaseScrapper):
                      'OUTPUTMODE': 'JSON',
                      'SEPARADOR':'',
                      'PUBL-C': day.strftime("%Y%m%d"),
-                     'SECC-C':'BOA%2Bo%2BDisposiciones%2Bo%2BJusticia%2Bo%2BAnuncios'
+                     'SECC-C':'BOA%2Bo%2BDisposiciones%2Bo%2BJusticia'
                      # versión completa (todas las secciones, incluyendo personal, etc):
                      # 'SECC-C':'BOA%2Bo%2BDisposiciones%2Bo%2BPersonal%2Bo%2BAcuerdos%2Bo%2BJusticia%2Bo%2BAnuncios' 
                      }

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -1,0 +1,125 @@
+import logging as lg
+import tempfile
+import typing as tp
+from datetime import date
+import random
+import json 
+
+import requests
+
+from src.etls.boa.metadata import BOAMetadataDocument
+from src.etls.common.metadata import MetadataDocument
+from src.etls.common.scrapper import BaseScrapper
+from src.etls.common.utils import ScrapperError
+from src.initialize import initialize_logging
+
+
+initialize_logging()
+
+
+class BOAScrapper(BaseScrapper):
+    def __init__(self):
+        self.base_url = "https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI"
+        self.user_agents = [
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15"
+        ]
+        self.headers = {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
+            "Connection": "keep-alive",
+            "User-Agent": random.choice(self.user_agents),
+        }    
+
+
+    def download_day(self, day: date) -> tp.List[BOAMetadataDocument]:
+        """Download all the documents for a specific date."""
+        try:
+            logger = lg.getLogger(self.download_day.__name__)
+            logger.info("Downloading BOA content for day %s", day)
+            params ={'CMD': 'VERLST',
+                     'BASE': 'BZHT',
+                     'DOCS': '1-250',
+                     'SEC': 'OPENDATABOAJSONAPP',
+                     'OUTPUTMODE': 'JSON',
+                     'SEPARADOR':'',
+                     'PUBL-C': day.strftime("%Y%m%d"),
+                     'SECC-C':'BOA%2Bo%2BDisposiciones%2Bo%2BJusticia%2Bo%2BAnuncios'
+                     # versión completa (todas las secciones, incluyendo personal, etc):
+                     # 'SECC-C':'BOA%2Bo%2BDisposiciones%2Bo%2BPersonal%2Bo%2BAcuerdos%2Bo%2BJusticia%2Bo%2BAnuncios' 
+                     }
+            response = requests.get(self.base_url, params=params)
+            raw_result = response.text
+            if '<span class="titulo">No se han recuperado documentos</span>' in raw_result:
+                logger.info(f"No hay contenido disponible para el día {day}")
+                return []
+            if response.status_code != 200:
+                response.raise_for_status() 
+            result_json = json.loads(raw_result)
+            disposiciones = []
+            for doc in result_json:
+                content = doc['Texto']
+                numero_boletin = doc['Numeroboletin']
+                identificador = doc['DOCN']
+                departamento = doc['Emisor']
+                url_pdf_raw = doc['UrlPdf']
+                url_pdf = url_pdf_raw.split('´`')[0][1:]
+                seccion = doc['Seccion']
+                if not content or not numero_boletin or not identificador or not departamento or not url_pdf or not seccion:
+                    raise ScrapperError("No se pudo encontrar alguno de los elementos requeridos.")
+                
+                clean_text = content.replace('<br/>', '')
+
+                with tempfile.NamedTemporaryFile("w", delete=False, encoding='utf-8') as fn:
+                    fn.write(clean_text)           
+                document_data = BOAMetadataDocument(**{"filepath": fn.name,
+                                                       "numero_boletin": numero_boletin,
+                                                       "identificador": identificador,
+                                                       "departamento": departamento,
+                                                       "url_pdf": url_pdf,
+                                                       "seccion": seccion, 
+                                                       })
+                titulo = doc['Titulo']
+                url_boletin_raw = doc['UrlBCOM'] 
+                url_boletin = url_boletin_raw.split('´`')[0][1:]
+                subseccion = doc['Subseccion']
+                codigo_materia = doc['CodigoMateria']
+                rango = doc['Rango']
+                fecha_disposicion = doc['Fechadisposicion']
+
+                if not titulo:
+                    raise ScrapperError("No se pudo encontrar el título en uno de los bloques.") 
+                
+                disposition_summary = {
+                    "titulo": titulo,                        
+                    "url_boletin": url_boletin,
+                    "subseccion": subseccion,
+                    "codigo_materia": codigo_materia,
+                    "rango": rango,
+                    "fecha_disposicion": fecha_disposicion,
+                    "fecha_publicacion": day.strftime("%Y-%m-%d"), 
+                    "anio": str(day.year),
+                    "mes": str(day.month),
+                    "dia": str(day.day),
+                }
+                for atributo, valor in disposition_summary.items():
+                        setattr(document_data, atributo, valor)
+                disposiciones.append(document_data)
+            return disposiciones
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Error de red o HTTP al intentar acceder a {self.base_url}: {e}")
+        except Exception as e:
+            raise Exception(f"Error inesperado: {e}")
+        
+
+    def download_document(self, url: str) -> MetadataDocument:
+        """ En este caso, dado que al acceder a la url diaria, el BOA devuelve el texto de todos los
+            boletines en un JSON, no es necesario hacer uso de un método download_document(). 
+            De todas formas, se debe incluir para el correcto funcionamiento del programa, ya que
+            la clase BaseScrapper requiere que exista este método."""
+        pass

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -18,6 +18,13 @@ from src.initialize import initialize_logging
 initialize_logging()
 
 
+def _remove_html_tags(text):
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(text, parser)
+    clean_text = etree.tostring(tree, encoding="unicode", method='text') 
+    return clean_text.strip()
+
+
 class BOAScrapper(BaseScrapper):
     def __init__(self):
         self.base_url = "https://www.boa.aragon.es/cgi-bin/EBOA/BRSCGI"
@@ -37,11 +44,6 @@ class BOAScrapper(BaseScrapper):
             "User-Agent": random.choice(self.user_agents),
         }    
 
-    def _remove_html_tags(self, text):
-        parser = etree.HTMLParser()
-        tree = etree.fromstring(text, parser)
-        clean_text = etree.tostring(tree, encoding="unicode", method='text') 
-        return clean_text.strip()
     
     def download_day(self, day: date) -> tp.List[BOAMetadataDocument]:
         """Download all the documents for a specific date."""
@@ -79,7 +81,7 @@ class BOAScrapper(BaseScrapper):
                 if not content or not numero_boletin or not identificador or not departamento or not url_pdf or not seccion:
                     raise ScrapperError("No se pudo encontrar alguno de los elementos requeridos.")
                 
-                clean_text = self._remove_html_tags(content)
+                clean_text = _remove_html_tags(content)
 
                 with tempfile.NamedTemporaryFile("w", delete=False, encoding='utf-8') as fn:
                     fn.write(clean_text)           

--- a/src/etls/boa/scrapper.py
+++ b/src/etls/boa/scrapper.py
@@ -39,7 +39,7 @@ def _extract_metadata(doc: dict) -> tp.Dict:
         pass
     
     try:
-        metadata_dict["departamento"] = doc["Emisor"]
+        metadata_dict["departamento"] = doc["Emisor"].capitalize()
     except KeyError:
         pass
     
@@ -74,12 +74,14 @@ def _extract_metadata(doc: dict) -> tp.Dict:
         pass
     
     try:
-        metadata_dict["rango"] = doc["Rango"]
+        metadata_dict["rango"] = doc["Rango"].capitalize()
     except KeyError:
         pass
 
     try:
-        metadata_dict["fecha_disposicion"] = doc["Fechadisposicion"]
+        fecha_disp_raw = doc["Fechadisposicion"]
+        fecha_disposicion = fecha_disp_raw[0:4]+"-"+fecha_disp_raw[4:6]+"-"+fecha_disp_raw[6:8]
+        metadata_dict["fecha_disposicion"] = fecha_disposicion
     except KeyError:
         pass
     
@@ -135,9 +137,9 @@ class BOAScrapper(BaseScrapper):
                 metadata_doc = self.download_document(json.dumps(doc))
                 fecha_publicacion_atributos = {
                     "fecha_publicacion": day.strftime("%Y-%m-%d"), 
-                    "anio": str(day.year),
-                    "mes": str(day.month),
-                    "dia": str(day.day),
+                    "anio": day.strftime("%Y"),
+                    "mes": day.strftime("%m"),
+                    "dia": day.strftime("%d"),
                 }
                 for atributo, valor in fecha_publicacion_atributos.items():
                         setattr(metadata_doc, atributo, valor)

--- a/src/etls/jobs.py
+++ b/src/etls/jobs.py
@@ -7,6 +7,7 @@ from src.etls.bopz.load import today as bopz_today
 from src.etls.bocm.load import today as bocm_today
 from src.etls.bopv.load import today as bopv_today
 from src.etls.boja.load import today as boja_today
+from src.etls.boa.load import today as boa_today
 from src.initialize import initialize_app
 
 
@@ -18,6 +19,7 @@ schedule.every().day.at("11:05").do(bopz_today, init_objects=INIT_OBJECTS)
 schedule.every().day.at("11:10").do(bocm_today, init_objects=INIT_OBJECTS)
 schedule.every().day.at("11:15").do(bopv_today, init_objects=INIT_OBJECTS)
 schedule.every().day.at("11:20").do(boja_today, init_objects=INIT_OBJECTS)
+schedule.every().day.at("11:25").do(boa_today, init_objects=INIT_OBJECTS)
 # TODO: monthly jobs
 
 while True:


### PR DESCRIPTION
Implemento la ETL del BOA siguiendo los estándares comunes al resto de boletines. 

Este scraper tiene una particularidad: a partir de una fecha dada, se puede obtener una url que devuelve todos los boletines completos, con sus metadatos correspondientes, de una vez (véase la clase BOAScrapper y el README). Por lo tanto, no es necesaria una función download_documents(url), dado que  no accedemos a los documentos uno a uno. Es por eso que he escrito el método download_documents vacío, ya que la clase hereda de BaseScrapper y tenía que incluirlo igualmente (creo).

Lo he probado en local y se integra en el programa sin errores:

`python -m src.etls.boa.load dates 2024/01/01 2024/01/31`