### PR TITLE
Fix file deletion after splitting documents

### DIFF
--- a/src/etls/common/etl.py
+++ b/src/etls/common/etl.py
@@ -41,9 +41,9 @@ class ETL:
                 chunk_overlap=self._config_loader["chunk_overlap"],
             )
             docs_chunks += text_splitter.split_documents(documents)
-        if doc:
-            logger.info("Removing file %s", doc.filepath)
-            os.remove(doc.filepath)
+            if doc:
+                logger.info("Removing file %s", doc.filepath)
+                os.remove(doc.filepath)
         logger.info("Splitted %s documents in %s chunks", len(docs), len(docs_chunks))
         return docs_chunks
 


### PR DESCRIPTION
Se ha corregido un error en el proceso de eliminación de archivos. Anteriormente, solo se eliminaba el último archivo. Con este cambio elimina dentro de bucle cada documento procesado.